### PR TITLE
fix: improve whisper-ctranslate2 path detection on Windows

### DIFF
--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -56,6 +56,8 @@ type Messages struct {
 	InvalidPath     string
 	TranscribeFail  string
 	UnsupportedOS   string
+	WhisperNotFound string
+	WhisperLocation string
 
 	// Recording messages
 	RecordingDevice string
@@ -141,6 +143,8 @@ var messagesEN = Messages{
 	InvalidPath:     "Invalid file path: %v",
 	TranscribeFail:  "Transcription failed: %v",
 	UnsupportedOS:   "Log viewing not supported on this platform",
+	WhisperNotFound: "whisper-ctranslate2 not found. Install with: pip install whisper-ctranslate2",
+	WhisperLocation: "To check installation location: pip show whisper-ctranslate2",
 
 	// Recording messages
 	RecordingDevice: "Recording Device",
@@ -226,6 +230,8 @@ var messagesJA = Messages{
 	InvalidPath:     "無効なファイルパス: %v",
 	TranscribeFail:  "文字起こしに失敗: %v",
 	UnsupportedOS:   "このプラットフォームではログ表示はサポートされていません",
+	WhisperNotFound: "whisper-ctranslate2が見つかりません。インストール: pip install whisper-ctranslate2",
+	WhisperLocation: "インストール場所の確認: pip show whisper-ctranslate2",
 
 	// Recording messages
 	RecordingDevice: "録音デバイス",


### PR DESCRIPTION
## Summary
Windows環境でのwhisper-ctranslate2パス検出を改善し、より多くのインストールパターンに対応

現在のWindows環境で発生している「whisper-ctranslate2が見つからない」エラーに対応するため、パス検索の改善とエラーメッセージの明確化を実装しました。

## Changes Made

### 🔍 パス検索の拡張
- pip --userインストール: `%APPDATA%\Roaming\Python\PythonXX\Scripts`
- システムインストール: `C:\PythonXX\Scripts`
- ドット記法バージョン: `Python3.12`形式のパス
- ユーザープロファイル: `%USERPROFILE%\AppData\Local\Programs\Python`

### 📝 エラーメッセージの改善
- whisper-ctranslate2が見つからない場合の詳細な案内
- インストール手順: `pip install whisper-ctranslate2`
- インストール場所確認: `pip show whisper-ctranslate2`
- 日本語・英語の両方に対応

### 🐛 デバッグ機能の追加
- デバッグモードで検索したパスをログ出力
- 見つかった場合は実際のパスを表示
- 見つからない場合も検索結果を明示

## Test Results
✅ すべてのテストが成功
✅ ビルドが正常に完了

## Impact
この修正により、Windows環境でのwhisper-ctranslate2検出成功率が大幅に向上し、インストールされているにも関わらず見つからない問題が解決されます。

🤖 Generated with [Claude Code](https://claude.ai/code)