### PR TITLE
fix: Windows環境での入力フォルダパス問題を修正

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -179,13 +179,19 @@ func DisplayLogs(config *config.Config) {
 }
 
 func OpenDirectory(dirPath string) error {
+	// Convert to absolute path for Windows explorer compatibility
+	absPath, err := filepath.Abs(dirPath)
+	if err != nil {
+		absPath = dirPath // Fallback to original path
+	}
+	
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "windows":
 		// Explorer doesn't work with HideWindow flag, use regular exec.Command
-		cmd = exec.Command("explorer", dirPath)
+		cmd = exec.Command("explorer", absPath)
 	case "darwin":
-		cmd = createCommand("open", dirPath)
+		cmd = createCommand("open", absPath)
 	default:
 		return fmt.Errorf("opening directories not supported on this platform")
 	}


### PR DESCRIPTION
## 概要
- Windows環境で入力フォルダボタンを押すと、設定されたパスではなくドキュメントフォルダが開く問題を修正
- 特に初回起動時（config.jsonなし）に発生

## 変更内容
- `OpenDirectory`関数で相対パスを絶対パスに変換してからexplorerに渡すように修正
- エラー時は元のパスにフォールバック
- KISS原則に従い最小限の変更で実装

## テスト内容
- [x] Windows環境での初回起動時の動作確認
- [x] 相対パス・絶対パス両方での動作確認
- [x] macOS環境での互換性確認

🤖 Generated with [Claude Code](https://claude.ai/code)