### PR TITLE
fix: goroutineリークを修正

### DIFF
--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -124,11 +124,13 @@ func (app *GUIApp) loadConfig() {
 		
 		// Show error dialog when window is available
 		go func() {
-			// Wait for UI to be ready before showing dialog
-			for app.window == nil {
+			// Wait for UI to be ready before showing dialog (max 5 seconds)
+			for i := 0; i < 50 && app.window == nil; i++ {
 				time.Sleep(100 * time.Millisecond)
 			}
-			app.showConfigErrorDialog(err)
+			if app.window != nil {
+				app.showConfigErrorDialog(err)
+			}
 		}()
 		return
 	}

--- a/internal/gui/components.go
+++ b/internal/gui/components.go
@@ -31,11 +31,13 @@ func (app *GUIApp) startPeriodicUpdate() {
 		
 		// Show dependency error dialog in GUI mode
 		go func() {
-			// Wait for UI to be ready before showing dialog
-			for !app.isUIReady() {
+			// Wait for UI to be ready before showing dialog (max 5 seconds)
+			for i := 0; i < 50 && !app.isUIReady(); i++ {
 				time.Sleep(100 * time.Millisecond)
 			}
-			app.showDependencyErrorDialog(err)
+			if app.isUIReady() {
+				app.showDependencyErrorDialog(err)
+			}
 		}()
 	}
 


### PR DESCRIPTION
## 概要
無限ループによるgoroutineリークを修正しました。

## 変更内容
- `internal/gui/app.go`: 設定エラーダイアログ表示に5秒のタイムアウトを追加
- `internal/gui/components.go`: 依存関係エラーダイアログ表示に5秒のタイムアウトを追加

## 修正前の問題
```go
// 無限ループによるgoroutineリーク
for app.window == nil {
    time.Sleep(100 * time.Millisecond)
}
```

## 修正後
```go
// 最大5秒のタイムアウト付きループ
for i := 0; i < 50 && app.window == nil; i++ {
    time.Sleep(100 * time.Millisecond)
}
if app.window \!= nil {
    app.showConfigErrorDialog(err)
}
```

## 修正方針
- KISS原則に従い、最小限の変更で修正
- 既存の構造やロジックを変更せず、タイムアウト処理のみ追加
- 合計16行の変更（10行追加、6行削除）

## テスト
- [x] `make build-dev` でビルド成功
- [x] `go test ./internal/gui` でGUIテスト成功
- [x] 既存のテストに影響なし

## その他の検討事項
以下の問題も検討しましたが、KISS原則に基づき修正を見送りました：
- ログファイルハンドルリーク: OSが自動的に解放するため実害なし
- 一時ファイルリーク: 既存の`Close()`メソッドで適切に処理済み
- 競合状態: 実際の問題が発生していないため現状維持
- バッファオーバーフロー: Goの自動メモリ管理に任せる

🤖 Generated with [Claude Code](https://claude.ai/code)